### PR TITLE
Funcion para transformar expresion

### DIFF
--- a/headers/lineController.hpp
+++ b/headers/lineController.hpp
@@ -33,3 +33,27 @@ void replaceAll(std::string& str, const std::string& from, const std::string& to
         start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
     }
 }
+
+void transformar_string(string *expresion){
+    string ops_pseudo[]={"**","div", "mod","~", "¬"};
+    string ops_reales[]={"^","/", "%", "not"};
+
+    //TRANSFORMAR EXPONENCIACION
+    replaceAll(*expresion,ops_pseudo[0],ops_reales[0]);
+    
+    //TRANSFORMAR OPERADOR DIV
+        //BUSCAR Y REEMPLAZAR CON REGEX_REPLACE
+        regex regexp("[[ ]div[ ]"); 
+        std::string output = std::regex_replace(*expresion, regexp, "/");
+        *expresion=output;
+
+    //TRANSFORMAR OPERADOR MOD
+        //BUSCAR Y REEMPLAZAR CON REGEX_REPLACE
+        regex regexp2("[[ ]mod[ ]"); 
+        std::string output2 = std::regex_replace(*expresion, regexp2, "%");
+        *expresion=output2;
+
+    //TRANSFORMAR OPERADOR NOT
+    replaceAll(*expresion,ops_pseudo[3],ops_reales[3]);
+    replaceAll(*expresion,ops_pseudo[4],ops_reales[3]);
+}


### PR DESCRIPTION
Hice esto esta mañana si quieres revísalo y pruébalo, pero es parte de lo que necesitabas para luego resolver las expresiones con la librería que encontraste. Es una función que reemplaza los operadores de pseudo (exponenciación, div, mod y not por ahora), lo único es que habría que verificar que el usuario al utilizar div y mod debe dejar espacios a los lados para que funcione 
(Ejemplo: 5 div 2)